### PR TITLE
Fix Silver5 split Aspid kills

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -1541,15 +1541,18 @@ namespace LiveSplit.HollowKnight {
                         || store.killsColMosquitoStart - mem.PlayerData<int>(Offset.killsColMosquito) > 5
                         || store.killsColFlyingSentryStart - mem.PlayerData<int>(Offset.killsColFlyingSentry) > 4;
                     break;
-                case SplitName.Silver5: // 2 × Aspid, 2 × Squit, 5 × Infected Gruzzer, not checking for aspid kills here because i think something weird is going on with their journal data stuff
+                case SplitName.Silver5: // 2 × Aspid, 2 × Squit, 5 × Infected Gruzzer, aspid kills in Colo 2 use killsSuperSpitter, even though Colo 1 and 3 use killsSpitter
                     shouldSplit =
                         store.killsBurstingBouncerStart - mem.PlayerData<int>(Offset.killsBurstingBouncer) == 5
-                        && store.killsColMosquitoStart - mem.PlayerData<int>(Offset.killsColMosquito) == 7;
+                        && store.killsColMosquitoStart - mem.PlayerData<int>(Offset.killsColMosquito) == 7
+                        && store.killsSuperSpitterStart - mem.PlayerData<int>(Offset.killsSuperSpitter) == 2;
                     shouldSkip =
                         mem.PlayerData<int>(Offset.killsBurstingBouncer) == 0
                         || mem.PlayerData<int>(Offset.killsColMosquito) == 0
+                        || mem.PlayerData<int>(Offset.killsSuperSpitter) == 0
                         || store.killsBurstingBouncerStart - mem.PlayerData<int>(Offset.killsBurstingBouncer) > 5
-                        && store.killsColMosquitoStart - mem.PlayerData<int>(Offset.killsColMosquito) > 7;
+                        && store.killsColMosquitoStart - mem.PlayerData<int>(Offset.killsColMosquito) > 7
+                        && store.killsSuperSpitterStart - mem.PlayerData<int>(Offset.killsSuperSpitter) > 2;
                     break;
                 case SplitName.Silver6: // 1 × Heavy Fool, 3 × Belfly
                     shouldSplit =

--- a/HollowKnightStoredData.cs
+++ b/HollowKnightStoredData.cs
@@ -33,6 +33,7 @@ namespace LiveSplit.HollowKnight
         public int killsColRollerStart { get; set; }
         public int killsColMinerStart { get; set; }
         public int killsSpitterStart { get; set; }
+        public int killsSuperSpitterStart { get; set; }
         public int killsBuzzerStart { get; set; }
         public int killsBigBuzzerStart { get; set; }
         public int killsBurstingBouncerStart { get; set; }
@@ -76,6 +77,7 @@ namespace LiveSplit.HollowKnight
             killsColRollerStart = mem.PlayerData<int>(Offset.killsColRoller);
             killsColMinerStart = mem.PlayerData<int>(Offset.killsColMiner);
             killsSpitterStart = mem.PlayerData<int>(Offset.killsSpitter);
+            killsSuperSpitterStart = mem.PlayerData<int>(Offset.killsSuperSpitter);
             killsBuzzerStart = mem.PlayerData<int>(Offset.killsBuzzer);
             killsBigBuzzerStart = mem.PlayerData<int>(Offset.killsBigBuzzer);
             killsBurstingBouncerStart = mem.PlayerData<int>(Offset.killsBurstingBouncer);


### PR DESCRIPTION
Aspid kills in Colo 2 use `killsSuperSpitter`, even though Colo 1 and 3 use `killsSpitter`.

Before this PR, if you leave 1 Aspid alive but kill everything else in Colo 2 Wave 5, the autosplitter will wrongly split `Silver5` too early, before you kill the Aspid.

After this PR, it should only split `Silver5` when all the wave 5 enemies are killed, Aspids included.

A dll for testing is on my [Silver5-Aspid-2-dll](https://github.com/AlexKnauth/LiveSplit.HollowKnight/tree/Silver5-Aspid-2-dll) branch.

Testing:
 - [x] Test on 1578
 - [x] Test on 1432
 - [x] Test on 1221